### PR TITLE
Fix default keybinding

### DIFF
--- a/src/main/java/mine/block/spoticraft/client/SpoticraftClient.java
+++ b/src/main/java/mine/block/spoticraft/client/SpoticraftClient.java
@@ -101,7 +101,7 @@ public class SpoticraftClient implements ClientModInitializer {
         var key = KeyBindingHelper.registerKeyBinding(new KeyBinding(
                 "key.spotify.open",
                 InputUtil.Type.KEYSYM,
-                GLFW.GLFW_KEY_P,
+                GLFW.GLFW_KEY_O,
                 "category.spotify.main"
         ));
 


### PR DESCRIPTION
Seemingly a typo, P conflicts with vanilla, O is mentioned in this repository's description