### PR TITLE
Do not play in-game music if Spotify is playing

### DIFF
--- a/src/main/java/mine/block/spoticraft/client/mixin/SoundSystemMixin.java
+++ b/src/main/java/mine/block/spoticraft/client/mixin/SoundSystemMixin.java
@@ -1,0 +1,21 @@
+package mine.block.spoticraft.client.mixin;
+
+import mine.block.spoticraft.client.SpoticraftClient;
+import mine.block.spotify.SpotifyUtils;
+import net.minecraft.client.sound.SoundInstance;
+import net.minecraft.client.sound.SoundSystem;
+import net.minecraft.sound.SoundCategory;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(SoundSystem.class)
+public class SoundSystemMixin {
+    @Inject(method = "play(Lnet/minecraft/client/sound/SoundInstance;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/sound/SoundInstance;getCategory()Lnet/minecraft/sound/SoundCategory;"), cancellable = true)
+    public void spoticraft$cancelMusicIfSpotifyPlaying(SoundInstance sound, CallbackInfo ci) {
+        if (sound.getCategory() == SoundCategory.MUSIC && SpotifyUtils.NOW_PLAYING != null && SpotifyUtils.NOW_PLAYING.getIs_playing()) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/mine/block/spotify/SpotifyUtils.java
+++ b/src/main/java/mine/block/spotify/SpotifyUtils.java
@@ -102,6 +102,8 @@ public class SpotifyUtils {
             if (MinecraftClient.getInstance().inGameHud != null && !(MinecraftClient.getInstance().currentScreen instanceof SpotifyScreen) && NOW_ART != null) {
                 MinecraftClient.getInstance().getToastManager().add(new SpotifyToast(currentlyPlaying));
             }
+        } else if (NOW_PLAYING.getIs_playing() != currentlyPlaying.getIs_playing()) {
+            NOW_PLAYING = currentlyPlaying;
         }
 
 

--- a/src/main/resources/spoticraft.mixin.json
+++ b/src/main/resources/spoticraft.mixin.json
@@ -6,7 +6,8 @@
   "mixins": [
   ],
   "client": [
-    "TitleScreenMixin"
+    "TitleScreenMixin",
+    "SoundSystemMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This only cancels music that starts playing, instead of muting music that already is playing, because there's a quite large latency between actually starting a song and Spoticraft noticing. it's too jarring otherwise
