### PR TITLE
add owo config screen and modmenu integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,18 +14,26 @@ repositories {
     jcenter()
     mavenCentral()
     maven {
-        url = uri("https://maven.pkg.github.com/Winterreisender/webviewko")
+        url = "https://maven.pkg.github.com/Winterreisender/webviewko"
         credentials {
             username = local.get("username")
             password = local.get("token")
         }
     }
     maven {
-        url "https://jitpack.io/"
+        name = "Gegy"
+        url = "https://maven.gegy.dev"
     }
     maven {
-        name 'Gegy'
-        url 'https://maven.gegy.dev'
+        name = "owo"
+        url = "https://maven.wispforest.io"
+    }
+    maven {
+        name = "TerraformersMC"
+        url = "https://maven.terraformersmc.com/releases"
+    }
+    maven {
+        url "https://jitpack.io"
     }
 }
 
@@ -37,7 +45,13 @@ dependencies {
 
     // Fabric API. This is technically optional, but you probably want it anyway.
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+
+    modRuntimeOnly "com.terraformersmc:modmenu:${project.modmenu_version}"
+
     modImplementation include("dev.lambdaurora:spruceui:${project.spruceui_version}")
+    modImplementation "io.wispforest:owo-lib:${project.owo_version}"
+    annotationProcessor "io.wispforest:owo-lib:${project.owo_version}"
+    include "io.wispforest:owo-lib:${project.owo_version}"
 
     implementation include('se.michaelthelin.spotify:spotify-web-api-java:7.2.1')
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,5 @@ archives_base_name=spoticraft
 # check this on https://modmuss50.me/fabric.html
 fabric_version=0.61.0+1.19.2
 spruceui_version=4.0.0+1.19
+owo_version=0.8.5+1.19
+modmenu_version=4.0.6

--- a/src/main/java/mine/block/spoticraft/client/SpoticraftClient.java
+++ b/src/main/java/mine/block/spoticraft/client/SpoticraftClient.java
@@ -1,5 +1,7 @@
 package mine.block.spoticraft.client;
 
+import mine.block.spoticraft.client.config.SpoticraftConfig;
+import mine.block.spoticraft.client.config.SpoticraftConfigModel;
 import mine.block.spoticraft.client.ui.SpotifyScreen;
 import mine.block.spotify.SpotifyHandler;
 import mine.block.spotify.SpotifyUtils;
@@ -11,24 +13,29 @@ import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.util.InputUtil;
-import net.minecraft.data.client.BlockStateModelGenerator;
-import net.minecraft.data.client.TexturedModel;
 import org.lwjgl.glfw.GLFW;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 @Environment(EnvType.CLIENT)
 public class SpoticraftClient implements ClientModInitializer {
-    
-    public static final LiveWriteProperties CONFIG = new LiveWriteProperties();
+
+    public static final String MODID = "spoticraft";
+    public static final LiveWriteProperties SPOTIFY_CONFIG = new LiveWriteProperties();
     public static final Logger LOGGER = LoggerFactory.getLogger("Spoticraft");
     public static final String VERSION = "1.1.0";
+    public static final SpoticraftConfig MOD_CONFIG = SpoticraftConfig.createAndLoad();
 
     @Override
     public void onInitializeClient() {
-        SpotifyHandler.setup();
+        MOD_CONFIG.subscribeToResetSpotifyCredentials(SpoticraftConfigModel.Callbacks::onResetCredentials);
+        MOD_CONFIG.subscribeToAutoMuteIngameMusic(SpoticraftConfigModel.Callbacks::onToggleMuteMusic);
+        SpotifyHandler.setup(false);
 
         SpotifyHandler.PollingThread thread = new SpotifyHandler.PollingThread();
         ExecutorService checkTasksExecutorService = new ThreadPoolExecutor(1, 10,

--- a/src/main/java/mine/block/spoticraft/client/SpoticraftClient.java
+++ b/src/main/java/mine/block/spoticraft/client/SpoticraftClient.java
@@ -35,7 +35,13 @@ public class SpoticraftClient implements ClientModInitializer {
     public void onInitializeClient() {
         MOD_CONFIG.subscribeToResetSpotifyCredentials(SpoticraftConfigModel.Callbacks::onResetCredentials);
         MOD_CONFIG.subscribeToAutoMuteIngameMusic(SpoticraftConfigModel.Callbacks::onToggleMuteMusic);
-        SpotifyHandler.setup(false);
+
+        boolean reset = MOD_CONFIG.resetSpotifyCredentials();
+        if (reset) {
+            MOD_CONFIG.resetSpotifyCredentials(false);
+            MOD_CONFIG.save();
+        }
+        SpotifyHandler.setup(reset);
 
         SpotifyHandler.PollingThread thread = new SpotifyHandler.PollingThread();
         ExecutorService checkTasksExecutorService = new ThreadPoolExecutor(1, 10,

--- a/src/main/java/mine/block/spoticraft/client/config/SpoticraftConfigModel.java
+++ b/src/main/java/mine/block/spoticraft/client/config/SpoticraftConfigModel.java
@@ -4,6 +4,8 @@ import io.wispforest.owo.config.annotation.Config;
 import io.wispforest.owo.config.annotation.Modmenu;
 import mine.block.spoticraft.client.SpoticraftClient;
 import mine.block.spotify.SpotifyHandler;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.sound.SoundCategory;
 
 @Modmenu(modId = SpoticraftClient.MODID)
 @Config(name = SpoticraftClient.MODID + "/spoticraft", wrapperName = "SpoticraftConfig", defaultHook = true)
@@ -24,8 +26,9 @@ public class SpoticraftConfigModel {
         }
 
         public static void onToggleMuteMusic(boolean newValue) {
-            // TODO toggle ingame music
+            if(newValue) {
+                MinecraftClient.getInstance().getSoundManager().stopSounds(null, SoundCategory.MUSIC);
+            }
         }
-
     }
 }

--- a/src/main/java/mine/block/spoticraft/client/config/SpoticraftConfigModel.java
+++ b/src/main/java/mine/block/spoticraft/client/config/SpoticraftConfigModel.java
@@ -4,6 +4,7 @@ import io.wispforest.owo.config.annotation.Config;
 import io.wispforest.owo.config.annotation.Modmenu;
 import mine.block.spoticraft.client.SpoticraftClient;
 import mine.block.spotify.SpotifyHandler;
+import mine.block.spotify.SpotifyUtils;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.sound.SoundCategory;
 
@@ -26,7 +27,7 @@ public class SpoticraftConfigModel {
         }
 
         public static void onToggleMuteMusic(boolean newValue) {
-            if(newValue) {
+            if(newValue && SpotifyUtils.NOW_PLAYING != null && SpotifyUtils.NOW_PLAYING.getIs_playing()) {
                 MinecraftClient.getInstance().getSoundManager().stopSounds(null, SoundCategory.MUSIC);
             }
         }

--- a/src/main/java/mine/block/spoticraft/client/config/SpoticraftConfigModel.java
+++ b/src/main/java/mine/block/spoticraft/client/config/SpoticraftConfigModel.java
@@ -1,0 +1,31 @@
+package mine.block.spoticraft.client.config;
+
+import io.wispforest.owo.config.annotation.Config;
+import io.wispforest.owo.config.annotation.Modmenu;
+import mine.block.spoticraft.client.SpoticraftClient;
+import mine.block.spotify.SpotifyHandler;
+
+@Modmenu(modId = SpoticraftClient.MODID)
+@Config(name = SpoticraftClient.MODID + "/spoticraft", wrapperName = "SpoticraftConfig", defaultHook = true)
+public class SpoticraftConfigModel {
+
+    public boolean autoMuteIngameMusic = false;
+
+    public boolean resetSpotifyCredentials = false;
+
+    public static class Callbacks {
+
+        public static void onResetCredentials(boolean newValue) {
+            if(newValue) {
+                SpoticraftClient.MOD_CONFIG.resetSpotifyCredentials(false);
+                SpoticraftClient.MOD_CONFIG.save();
+                SpotifyHandler.setup(true);
+            }
+        }
+
+        public static void onToggleMuteMusic(boolean newValue) {
+            // TODO toggle ingame music
+        }
+
+    }
+}

--- a/src/main/java/mine/block/spoticraft/client/mixin/SoundSystemMixin.java
+++ b/src/main/java/mine/block/spoticraft/client/mixin/SoundSystemMixin.java
@@ -14,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class SoundSystemMixin {
     @Inject(method = "play(Lnet/minecraft/client/sound/SoundInstance;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/sound/SoundInstance;getCategory()Lnet/minecraft/sound/SoundCategory;"), cancellable = true)
     public void spoticraft$cancelMusicIfSpotifyPlaying(SoundInstance sound, CallbackInfo ci) {
-        if (sound.getCategory() == SoundCategory.MUSIC && SpotifyUtils.NOW_PLAYING != null && SpotifyUtils.NOW_PLAYING.getIs_playing()) {
+        if (sound.getCategory() == SoundCategory.MUSIC && SpoticraftClient.MOD_CONFIG.autoMuteIngameMusic() && SpotifyUtils.NOW_PLAYING != null && SpotifyUtils.NOW_PLAYING.getIs_playing()) {
             ci.cancel();
         }
     }

--- a/src/main/java/mine/block/spotify/SpotifyUtils.java
+++ b/src/main/java/mine/block/spotify/SpotifyUtils.java
@@ -1,10 +1,12 @@
 package mine.block.spotify;
 
+import mine.block.spoticraft.client.SpoticraftClient;
 import mine.block.spoticraft.client.ui.SpotifyScreen;
 import mine.block.spoticraft.client.ui.SpotifyToast;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.texture.NativeImage;
 import net.minecraft.client.texture.NativeImageBackedTexture;
+import net.minecraft.sound.SoundCategory;
 import net.minecraft.util.Identifier;
 import se.michaelthelin.spotify.model_objects.miscellaneous.CurrentlyPlaying;
 import se.michaelthelin.spotify.model_objects.specification.Episode;
@@ -62,6 +64,11 @@ public class SpotifyUtils {
         if(!MC_LOADED) return;
         if (NOW_PLAYING == null || !NOW_PLAYING.getItem().getId().equals(currentlyPlaying.getItem().getId())) {
             NOW_PLAYING = currentlyPlaying;
+            MinecraftClient.getInstance().submit(() -> {
+                if(SpoticraftClient.MOD_CONFIG.autoMuteIngameMusic() && SpotifyUtils.NOW_PLAYING != null && SpotifyUtils.NOW_PLAYING.getIs_playing()) {
+                    MinecraftClient.getInstance().getSoundManager().stopSounds(null, SoundCategory.MUSIC);
+                }
+            });
 
             var item = currentlyPlaying.getItem();
 

--- a/src/main/java/mine/block/spotify/server/CallbackHandler.java
+++ b/src/main/java/mine/block/spotify/server/CallbackHandler.java
@@ -61,9 +61,9 @@ public class CallbackHandler implements HttpHandler {
             SpotifyHandler.SPOTIFY_API.setRefreshToken(credentials.getRefreshToken());
 
             LOGGER.info("Saving credentials.");
-            SpoticraftClient.CONFIG.put("token", credentials.getAccessToken());
-            SpoticraftClient.CONFIG.put("refresh-token", credentials.getRefreshToken());
-            SpoticraftClient.CONFIG.put("version", SpoticraftClient.VERSION);
+            SpoticraftClient.SPOTIFY_CONFIG.put("token", credentials.getAccessToken());
+            SpoticraftClient.SPOTIFY_CONFIG.put("refresh-token", credentials.getRefreshToken());
+            SpoticraftClient.SPOTIFY_CONFIG.put("version", SpoticraftClient.VERSION);
             LOGGER.info("Saved Credentials.");
 
             server.stop(15);

--- a/src/main/java/mine/block/spotify/server/PreCallbackHandler.java
+++ b/src/main/java/mine/block/spotify/server/PreCallbackHandler.java
@@ -24,8 +24,8 @@ public class PreCallbackHandler implements HttpHandler {
 
             SpotifyHandler.SPOTIFY_API = SpotifyApi.builder().setClientId(clientID).setClientSecret(clientSecret).setRedirectUri(URI.create("http://localhost:23435/callback")).build();
 
-            SpoticraftClient.CONFIG.put("client-id", clientID);
-            SpoticraftClient.CONFIG.put("client-secret", clientSecret);
+            SpoticraftClient.SPOTIFY_CONFIG.put("client-id", clientID);
+            SpoticraftClient.SPOTIFY_CONFIG.put("client-secret", clientSecret);
 
             try (exchange) {
                 exchange.sendResponseHeaders(200, 0);

--- a/src/main/java/mine/block/utils/LiveWriteProperties.java
+++ b/src/main/java/mine/block/utils/LiveWriteProperties.java
@@ -5,16 +5,13 @@ import net.fabricmc.loader.api.FabricLoader;
 
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.Properties;
 
-import static mine.block.spoticraft.client.SpoticraftClient.LOGGER;
-
 public class LiveWriteProperties extends Properties {
 
-    private final Path pathToConfig = FabricLoader.getInstance().getConfigDir().resolve("spotify.cred");
+    private final Path pathToConfig = FabricLoader.getInstance().getConfigDir().resolve(SpoticraftClient.MODID).resolve("spotify.cred");
     public boolean empty = true;
 
     public LiveWriteProperties() {

--- a/src/main/resources/assets/spoticraft/lang/en_us.json
+++ b/src/main/resources/assets/spoticraft/lang/en_us.json
@@ -1,4 +1,8 @@
 {
   "key.spotify.open": "Open Spotify Screen",
-  "category.spotify.main": "Spoticraft"
+  "category.spotify.main": "Spoticraft",
+
+  "text.config.spoticraft/spoticraft.title": "Spoticraft",
+  "text.config.spoticraft/spoticraft.option.autoMuteIngameMusic": "Mute ingame music while playing",
+  "text.config.spoticraft/spoticraft.option.resetSpotifyCredentials": "Reset Spotify Credentials NOW"
 }

--- a/src/main/resources/assets/spoticraft/web/callback.html
+++ b/src/main/resources/assets/spoticraft/web/callback.html
@@ -34,7 +34,7 @@
     <p>
         Spoticraft has successfully logged into the Spotify API.
         <br>
-        You can close this window to continue the launching of Minecraft.
+        You may close this window now.
     </p>
     <hr />
     <h1>Support</h1>


### PR DESCRIPTION
This adds a basic config screen.
- adds an option to mute ingame music while spotify is playing (will also stop music that is already playing)
- adds a toggle to reset spotify credentials while the game is running (this is a bit of a hack due to owo-lib not having a button option; instead it uses a boolean option to indicate that the user wishes a reset on saving the config, or next startup

- move the config file AND spotify credentials file into a subdirectory (`.minecraft/config/spoticraft/`)